### PR TITLE
Add autotools based build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,12 @@
 *.xpi
 .sass-cache/
+
+Makefile
+Makefile.in
+config.log
+config.status
+configure
+install-sh
+*.m4
+missing
+autom4te.cache/

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,29 @@
+ACLOCAL_AMFLAGS = -I m4
+AM_CFLAGS =
+
+EXTRA_DIST = ${top_srcdir}/README.md \
+	     ${top_srcdir}/LICENSE \
+	     ${top_srcdir}/make-xpi.sh \
+	     ${top_srcdir}/arc-firefox-theme
+NULL =
+
+mkxpi:
+	${top_srcdir}/make-xpi.sh
+
+arc-firefox-theme-$(VERSION).xpi: mkxpi
+arc-darker-firefox-theme-$(VERSION).xpi:
+arc-dark-firefox-theme-$(VERSION).xpi:
+
+BUILT_SOURCES = \
+	arc-firefox-theme-$(VERSION).xpi \
+	arc-darker-firefox-theme-$(VERSION).xpi \
+	arc-dark-firefox-theme-$(VERSION).xpi
+
+CLEANFILES = \
+	$(BUILT_SOURCES)
+
+extensiondir = $(libdir)/firefox/extensions
+extension_DATA = \
+	arc-firefox-theme-$(VERSION).xpi \
+	arc-darker-firefox-theme-$(VERSION).xpi \
+	arc-dark-firefox-theme-$(VERSION).xpi

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,17 @@
+AC_INIT([arc-firefox-theme], [40.20150819], [https://github.com/horst3180/arc-firefox-theme/issues], [arc-firefox-theme], [https://github.com/horst3180/arc-firefox-theme])
+AM_INIT_AUTOMAKE([-Wno-portability no-dist-gzip dist-xz foreign subdir-objects tar-ustar])
+AC_PREFIX_DEFAULT(/usr/local)
+AM_SILENT_RULES([yes])
+
+
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT
+
+AC_MSG_RESULT([
+        arc-firefox-theme $VERSION
+        ========
+
+        prefix:                 ${prefix}
+        exec_prefix:            ${exec_prefix}
+        datarootdir:            ${datarootdir}
+])


### PR DESCRIPTION
Admittedly this could probably be done better, by folding in the make-xpi script, but I didn't want to remove that as its very likely quite useful for testing.

Also, distcheck /will/ fail, as `make-xpi.sh` knows nothing about separate src/build dir. But hey, `make dist` works :) (And would allow tagged releases)

In reality we should likely use `%.xpi` rule with `SUFFIXES: .xpi`, and pass `$*` to `make-xpi.sh` to case-check for which one to build (`case` for darker, dark, default to light)
