### PR TITLE
fix url drop down colors

### DIFF
--- a/arc-firefox-theme/chrome/browser/sass/browser-dark.css
+++ b/arc-firefox-theme/chrome/browser/sass/browser-dark.css
@@ -1755,7 +1755,7 @@ html|span.ac-tag {
 .ac-separator:not([selected=true]),
 .ac-url:not([selected=true]),
 .ac-action:not([selected=true]) {
-  color: -moz-nativehyperlinktext; }
+  color: #5294E2; }
 
 .ac-tags-text[selected] > html|span.ac-tag {
   background-color: HighlightText;

--- a/arc-firefox-theme/chrome/browser/sass/browser-darker.css
+++ b/arc-firefox-theme/chrome/browser/sass/browser-darker.css
@@ -1754,7 +1754,7 @@ html|span.ac-tag {
 .ac-separator:not([selected=true]),
 .ac-url:not([selected=true]),
 .ac-action:not([selected=true]) {
-  color: -moz-nativehyperlinktext; }
+  color: #5294E2; }
 
 .ac-tags-text[selected] > html|span.ac-tag {
   background-color: HighlightText;

--- a/arc-firefox-theme/chrome/browser/sass/browser-light.css
+++ b/arc-firefox-theme/chrome/browser/sass/browser-light.css
@@ -1754,7 +1754,7 @@ html|span.ac-tag {
 .ac-separator:not([selected=true]),
 .ac-url:not([selected=true]),
 .ac-action:not([selected=true]) {
-  color: -moz-nativehyperlinktext; }
+  color: #5294E2; }
 
 .ac-tags-text[selected] > html|span.ac-tag {
   background-color: HighlightText;


### PR DESCRIPTION
Fix the colors of the suggested URLs on the drop-down menu of the URL bar

This : 
- improves legibility on Arc Dark
- makes the theme more consistent on other variants

Before:
![before image](http://siphonay.fr/arcff/arcff-before.png)
After:
![after image](http://siphonay.fr/arcff/arcff-after.png)